### PR TITLE
必要ない比較を消したのとリファクタに伴うバグ修正

### DIFF
--- a/cs-ilp-codec-framework-test/Test/Org/Interledger/Encoding/Asn/Serializer/OpenTypeOerSerializerTest.cs
+++ b/cs-ilp-codec-framework-test/Test/Org/Interledger/Encoding/Asn/Serializer/OpenTypeOerSerializerTest.cs
@@ -92,6 +92,12 @@ namespace Test.Org.Interledger.Encoding.Asn.Serializer
                 SampleType actualValue = context.Read<SampleType>(stream);
                 this._output.WriteLine(string.Format("TestOpenTypeRead result,\n\t{0} :expected bytes\n\t{1} :actual bytes", BitConverter.ToString(octetBytes), BitConverter.ToString(actualValue.Bytes)));
                 Assert.Equal(octetBytes, actualValue.Bytes);
+
+                stream.Position = 0;
+                context.Write<SampleType>(actualValue, stream);
+                stream.Position = 0;
+                SampleType writtenValue = context.Read<SampleType>(stream);
+                Assert.Equal(actualValue, writtenValue);
             }
         }
     }
@@ -104,6 +110,26 @@ namespace Test.Org.Interledger.Encoding.Asn.Serializer
         public SampleType(byte[] bytes)
         {
             this.Bytes = bytes;
+        }
+
+        public override bool Equals(object obj)
+        {
+            if (this == obj)
+            {
+                return true;
+            }
+            if (obj == null || this.GetType() != obj.GetType())
+            {
+                return false;
+            }
+
+            SampleType other = (SampleType)obj;
+            return TestUtils.IsListEqual<byte>(this.Bytes, other.Bytes);
+        }
+
+        public override int GetHashCode()
+        {
+            return this.Bytes.GetHashCode();
         }
     }
 

--- a/cs-ilp-codec-framework-test/Test/Org/Interledger/Encoding/Asn/Serializer/SequenceOfSequenceOerSerializerTest.cs
+++ b/cs-ilp-codec-framework-test/Test/Org/Interledger/Encoding/Asn/Serializer/SequenceOfSequenceOerSerializerTest.cs
@@ -138,10 +138,6 @@ namespace Test.Org.Interledger.Encoding.Asn.Serializer
             }
 
             SampleSequence other = (SampleSequence)obj;
-            if (obj == other)
-            {
-                return true;
-            }
 
             byte[] thisNumbers = this.Numbers;
             byte[] otherNumbers = other.Numbers;
@@ -185,10 +181,6 @@ namespace Test.Org.Interledger.Encoding.Asn.Serializer
             }
 
             SampleSequenceOfSequence other = (SampleSequenceOfSequence)obj;
-            if (obj == other)
-            {
-                return true;
-            }
 
             if (this.Count != other.Count)
             {

--- a/cs-ilp-codec-framework/Org/Interledger/Encoding/Asn/Framework/AsnObjectSerializationContext.cs
+++ b/cs-ilp-codec-framework/Org/Interledger/Encoding/Asn/Framework/AsnObjectSerializationContext.cs
@@ -76,7 +76,7 @@ namespace Org.Interledger.Encoding.Asn.Framework
             {
                 using (MemoryStream stream = new MemoryStream())
                 {
-                    this.GetSerializer(instance).Write(instance, stream);
+                    this.GetSerializer(instance).Write(this, instance, stream);
                     return stream.GetBuffer();
                 }
             }

--- a/cs-ilp-codec-framework/Org/Interledger/Encoding/Asn/Serializers/Oer/OerLengthSerializer.cs
+++ b/cs-ilp-codec-framework/Org/Interledger/Encoding/Asn/Serializers/Oer/OerLengthSerializer.cs
@@ -71,12 +71,15 @@ namespace Org.Interledger.Encoding.Asn.Serializers.Oer
         {
             // because length of bytes is not always 8.
             // e.g. 3 bytes, it must be 8 bytes to be converted to ulong.
-            Array.Reverse(bytes);
-            if (bytes.Length < 8)
+            if (BitConverter.IsLittleEndian)
             {
-                byte[] enough = new byte[8];
-                Array.Copy(bytes, enough, bytes.Length);
-                bytes = enough;
+                Array.Reverse(bytes);
+                if (bytes.Length < 8)
+                {
+                    byte[] enough = new byte[8];
+                    Array.Copy(bytes, enough, bytes.Length);
+                    bytes = enough;
+                }
             }
             return BitConverter.ToUInt64(bytes, 0);
         }


### PR DESCRIPTION
- `==` での意味のない比較を行っている部分があった
- OpenType のオブジェクト読み込みがリファクタリングでバグっていたので修正